### PR TITLE
Restrict access to links.ini file

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -5,3 +5,8 @@
 	 RewriteCond %{REQUEST_FILENAME} !-d
 	 RewriteRule ^.*$ /index.php [L]
 </IfModule>
+
+<Files ~ "\.ini$">
+	Order allow,deny
+	Deny from all
+</Files>


### PR DESCRIPTION
Some implementations can be used to share public and private links in the same file. Deny access to links.ini file protects against exposure of all urls without any impact on application execution.